### PR TITLE
Add write_string_dataset method to GridFile

### DIFF
--- a/src/synthesizer_grids/grid_io.py
+++ b/src/synthesizer_grids/grid_io.py
@@ -302,7 +302,7 @@ class GridFile:
         # Finally, Write it!
         dset = self.hdf.create_dataset(
             key,
-            data=data.value,
+            data=data,
             shape=data.shape,
             dtype=dtype,
         )


### PR DESCRIPTION
Adds a `write_string_dataset` to `GridFile` to allow the saving of string based datasets that require encoding and don't have units.

## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
