### PR TITLE
Moves the weight variable to the root of the grid file

### DIFF
--- a/src/synthesizer_grids/grid_io.py
+++ b/src/synthesizer_grids/grid_io.py
@@ -466,6 +466,9 @@ class GridFile:
         # Write out the axis names to an attribute
         self.write_attribute("/", "axes", list(axes.keys()))
 
+        # Store the weight variable as an attribute
+        self.write_attribute("/", "WeightVariable", weight)
+
         # Parse descriptions and use defaults if not given
         for key in axes:
             if key in descriptions:
@@ -505,9 +508,9 @@ class GridFile:
             )
 
         # Write out the spectra grids
-        self.write_spectra(spectra, wavelength, weight=weight)
+        self.write_spectra(spectra, wavelength)
 
-    def write_spectra(self, spectra, wavelength, weight="initial_masses"):
+    def write_spectra(self, spectra, wavelength):
         """
         Write out the spectra grids.
 
@@ -520,11 +523,6 @@ class GridFile:
                 be the key used for the dataset.
             wavelength (unyt_array)
                 The wavelength array of the spectra grid.
-            weight (str)
-                The variable to used to normalise the spectra in the grid. For
-                instance, in most SPS models this will initial mass normalised,
-                the Synthesizer property for this is "initial_masses". By
-                default this is set to "initial_masses".
         """
         # Write out the wavelength array
         self.write_dataset(
@@ -533,9 +531,6 @@ class GridFile:
             "Wavelength of the spectra grid",
             log_on_read=False,
         )
-
-        # Store the weight variable as an attribute
-        self.write_attribute("spectra", "WeightVariable", weight)
 
         # Write out each spectra
         for key, val in spectra.items():

--- a/src/synthesizer_grids/incident/blackholes/install_broken_power_law.py
+++ b/src/synthesizer_grids/incident/blackholes/install_broken_power_law.py
@@ -47,10 +47,9 @@ def broken_power_law(x, edges, indices, normalisations=False, normalise=True):
             normalisations.append(norm)
 
     # now construct spectra
-    for e1, e2, ind, norm in zip(edges[0:],
-                                 edges[1:],
-                                 indices,
-                                 normalisations):
+    for e1, e2, ind, norm in zip(
+        edges[0:], edges[1:], indices, normalisations
+    ):
         # identify indices within the wavelength range
 
         s = (x >= e1) & (x < e2)
@@ -65,7 +64,6 @@ def broken_power_law(x, edges, indices, normalisations=False, normalise=True):
 
 
 if __name__ == "__main__":
-
     """
     Create incident AGN spectra assuming a broken power-law model.
 
@@ -87,32 +85,33 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # open the config file and extract parameters
-    with open(args.config_file, 'r') as file:
+    with open(args.config_file, "r") as file:
         parameters = yaml.safe_load(file)
 
-    model_name = parameters['model']
-    indices = parameters['indices']
-    edges_lam = np.array(parameters['edges']) * Angstrom
+    model_name = parameters["model"]
+    indices = parameters["indices"]
+    edges_lam = np.array(parameters["edges"]) * Angstrom
 
     # Model defintion dictionary
     model = {
-        'name': model_name,
-        'type': 'agn',
-        'family': 'broken_power_law',
+        "name": model_name,
+        "type": "agn",
+        "family": "broken_power_law",
     }
 
     # Define the grid filename and path
     out_filename = f"{args.grid_dir}/{model_name}.hdf5"
 
     # Define axes names
-    axes_names = [f'alpha{i+1}' for i, _ in enumerate(indices)]
+    axes_names = [f"alpha{i+1}" for i, _ in enumerate(indices)]
 
     # Define axes descriptions
     axes_descriptions = {}
     for i, axis_name in enumerate(axes_names):
         axes_descriptions[axis_name] = (
-            rf'The power-law slope between {edges_lam[i]} '
-            rf'\le \lambda/\AA < {edges_lam[i+1]}')
+            rf"The power-law slope between {edges_lam[i]} "
+            rf"\le \lambda/\AA < {edges_lam[i+1]}"
+        )
 
     # In this case the incident axes values are just the indices
     # but we also convert lists to arrays
@@ -141,7 +140,6 @@ if __name__ == "__main__":
     for i, alpha1 in enumerate(indices[0]):
         for j, alpha2 in enumerate(indices[1]):
             for k, alpha3 in enumerate(indices[2]):
-
                 # define the indices of the current model
                 indices_ = [alpha1, alpha2, alpha3]
 
@@ -152,7 +150,7 @@ if __name__ == "__main__":
     out_grid = GridFile(out_filename)
 
     # Define which axes are logged
-    log_on_read = {'alpha1': False, 'alpha2': False, 'alpha3': False}
+    log_on_read = {"alpha1": False, "alpha2": False, "alpha3": False}
 
     # Write everything out thats common to all models
     out_grid.write_grid_common(
@@ -162,6 +160,7 @@ if __name__ == "__main__":
         wavelength=lam,
         log_on_read=log_on_read,
         spectra={"incident": spec * erg / s / Hz},
+        weight="bolometric_luminosities",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/blackholes/install_relqso.py
+++ b/src/synthesizer_grids/incident/blackholes/install_relqso.py
@@ -24,7 +24,6 @@ from synthesizer_grids.parser import Parser
 sys.path.append("RELAGN/src/python_version")
 
 if __name__ == "__main__":
-
     # Import relagn module
     from relagn import relagn  # noqa: E402
 
@@ -37,22 +36,22 @@ if __name__ == "__main__":
         "accretion_rate_eddington",
         "spin",
         "cosine_inclination",
-        ]
+    ]
 
     axes_descriptions = {
         "mass": "blackhole mass",
-        "accretion_rate_eddington":
-        "BH accretion rate / Edding accretion rate [LEdd=eta MdotEdd c^2]",
+        "accretion_rate_eddington": "BH accretion rate / Eddington accretion"
+        " rate [LEdd=eta MdotEdd c^2]",
         "cosine_inclination": "cosine of the inclination",
         "spin": "dimensionless spin",
-        }
+    }
 
     axes_units = {
         "mass": Msun,
         "accretion_rate_eddington": None,
         "cosine_inclination": None,
         "spin": None,
-        }
+    }
 
     # Set up the command line arguments
     parser = Parser(description="RELQSO AGN model creation.")
@@ -64,46 +63,48 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # open the config file and extract parameters
-    with open(args.config_file, 'r') as file:
+    with open(args.config_file, "r") as file:
         parameters = yaml.safe_load(file)
 
-    model_name = parameters['model']
-    mass = 10**np.array(parameters['log10_mass'])
-    accretion_rate_eddington = 10**np.array(
-        parameters['log10_accretion_rate_eddington'])
-    spin = np.array(parameters['spin'])
+    model_name = parameters["model"]
+    mass = 10 ** np.array(parameters["log10_mass"])
+    accretion_rate_eddington = 10 ** np.array(
+        parameters["log10_accretion_rate_eddington"]
+    )
+    spin = np.array(parameters["spin"])
 
     # check whether isotropic or not
-    if isinstance(parameters['cosine_inclination'], float):
-        cosine_inclination = parameters['cosine_inclination']
-        axes_names.remove('cosine_inclination')
+    if isinstance(parameters["cosine_inclination"], float):
+        cosine_inclination = parameters["cosine_inclination"]
+        axes_names.remove("cosine_inclination")
         isotropic = True
     else:
-        cosine_inclination = np.array(parameters['cosine_inclination'])
+        cosine_inclination = np.array(parameters["cosine_inclination"])
         isotropic = False
 
     # Model defintion dictionary
     model = {
-        'name': model_name,
-        'type': 'agn',
-        'family': 'relqso',
+        "name": model_name,
+        "type": "agn",
+        "family": "relqso",
     }
 
     # Define the grid filename and path
     out_filename = f"{args.grid_dir}/{model_name}.hdf5"
 
     axes_values = {
-        'mass': mass,
-        'accretion_rate_eddington': accretion_rate_eddington,
-        'spin': spin,
+        "mass": mass,
+        "accretion_rate_eddington": accretion_rate_eddington,
+        "spin": spin,
     }
 
     if not isotropic:
-        axes_values['cosine_inclination'] = np.array(cosine_inclination)
+        axes_values["cosine_inclination"] = np.array(cosine_inclination)
 
     # the shape of the grid (useful for creating outputs)
     axes_shape = list(
-        [len(axes_values[axis_name]) for axis_name in axes_names])
+        [len(axes_values[axis_name]) for axis_name in axes_names]
+    )
 
     # define axes dictionary which is saved to the HDF5 file
     axes = {}
@@ -129,9 +130,7 @@ if __name__ == "__main__":
         for i2, accretion_rate_eddington_ in enumerate(
             axes_values["accretion_rate_eddington"]
         ):
-
             for i3, spin_ in enumerate(axes_values["spin"]):
-
                 if isotropic:
                     dagn = relagn(
                         a=spin_,
@@ -149,8 +148,8 @@ if __name__ == "__main__":
 
                 else:
                     for i4, cosine_inclination_ in enumerate(
-                            axes_values["cosine_inclination"]):
-
+                        axes_values["cosine_inclination"]
+                    ):
                         dagn = relagn(
                             a=spin_,
                             cos_inc=cosine_inclination_,
@@ -175,6 +174,7 @@ if __name__ == "__main__":
         descriptions=axes_descriptions,
         wavelength=lam,
         spectra={"incident": spec * erg / s / Hz},
+        weight="bolometric_luminosities",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_bc03-2016.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03-2016.py
@@ -340,6 +340,7 @@ def make_grid(variant, imf_type, input_dir, out_filename):
         spectra={"incident": spec * erg / s / Hz},
         alt_axes=("ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_bc03.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03.py
@@ -273,6 +273,7 @@ def make_grid(input_dir, grid_dir, synthesizer_model_name):
         spectra={"incident": spec * erg / s / Hz},
         alt_axes=("ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
@@ -173,6 +173,7 @@ def make_grid(original_model_name, bin, input_dir, grid_dir):
         spectra={"incident": spectra * erg / s / Hz},
         alt_axes=("log10ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Write datasets specific to BPASS

--- a/src/synthesizer_grids/incident/sps/install_bpass2.3.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.3.py
@@ -169,6 +169,7 @@ def make_single_alpha_grid(
         spectra={"incident": spectra * erg / s / Hz},
         alt_axes=("log10ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity
@@ -292,6 +293,7 @@ def make_full_grid(original_model_name, input_dir, grid_dir, bs="bin"):
         spectra={"incident": spectra * erg / s / Hz},
         alt_axes=("log10ages", "metallicities", "alpha_enhancements"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_fsps.py
+++ b/src/synthesizer_grids/incident/sps/install_fsps.py
@@ -95,6 +95,7 @@ def generate_grid(model):
         spectra={"incident": spec * erg / s / Hz},
         alt_axes=("log10ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_maraston05.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston05.py
@@ -106,6 +106,7 @@ def make_grid(model, imf, hr_morphology, input_dir, grid_dir):
         spectra={"incident": spec * erg / s / Hz},
         alt_axes=("ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_maraston11.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston11.py
@@ -122,6 +122,7 @@ def make_grid(model, imf, variant, output_dir, grid_dir):
         spectra={"incident": spec * erg / s / Hz},
         alt_axes=("ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_maraston13.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston13.py
@@ -98,6 +98,7 @@ def make_grid(model, imf, input_dir, grid_dir):
         spectra={"incident": spec * erg / s / Hz},
         log_on_read=log_on_read,
         alt_axes=("log10ages", "metallicities"),
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -101,6 +101,7 @@ def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
         spectra={"incident": spec * erg / s / Hz},  # check this unit
         alt_axes=("log10ages", "metallicities"),
         log_on_read=log_on_read,
+        weight="initial_masses",
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_yggdrasil.py
+++ b/src/synthesizer_grids/incident/sps/install_yggdrasil.py
@@ -217,6 +217,7 @@ def make_grid(input_dir, grid_dir, ver, fcov, model):
             spectra={f"nebular{add}": spec * erg / s / Hz},
             alt_axes=("log10ages", "metallicities"),
             log_on_read=log_on_read,
+            weight="initial_masses",
         )
 
     else:
@@ -237,6 +238,7 @@ def make_grid(input_dir, grid_dir, ver, fcov, model):
             spectra={"incident": interp_spec * erg / s / Hz},
             alt_axes=("log10ages", "metallicities"),
             log_on_read=log_on_read,
+            weight="initial_masses",
         )
 
         # Include the specific ionising photon luminosity


### PR DESCRIPTION
DWISOTT 

Also explicitly passing the weight argument to all instances of `write_grid_common` for clarity (and including the correct variable for blackholes)

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
