### PR TITLE
synthesizer.sed --> synthesizer.emissions to import Sed

### DIFF
--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -14,7 +14,7 @@ import re
 import numpy as np
 from synthesizer.grid import Grid
 from synthesizer.photoionisation import cloudy17, cloudy23
-from synthesizer.sed import Sed
+from synthesizer.emissions import Sed
 from synthesizer.units import has_units
 from unyt import Angstrom, Hz, cm, dimensionless, erg, eV, s, yr
 from utils import (

--- a/src/synthesizer_grids/grid_io.py
+++ b/src/synthesizer_grids/grid_io.py
@@ -38,7 +38,7 @@ import h5py
 import numpy as np
 from synthesizer._version import __version__ as synthesizer_version
 from synthesizer.photoionisation import Ions
-from synthesizer.sed import Sed
+from synthesizer.emissions import Sed
 from synthesizer.units import has_units
 from tqdm import tqdm
 from unyt import dimensionless, unyt_array


### PR DESCRIPTION
Adjusting where Sed is imported from - now imported from synthesizer.emissions rather than synthesizer.sed

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies to align with recent module enhancements for improved maintainability.  


<!-- end of auto-generated comment: release notes by coderabbit.ai -->