### PR TITLE
Update naming for Maraston grids

### DIFF
--- a/src/synthesizer_grids/incident/sps/install_maraston13.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston13.py
@@ -9,21 +9,20 @@ from synthesizer.conversions import llam_to_lnu
 from synthesizer_grids.grid_io import GridFile
 from synthesizer_grids.parser import Parser
 from unyt import Angstrom, Hz, dimensionless, erg, s, yr
+from utils import get_model_filename
 
 
-def make_grid(model, imf, input_dir, grid_dir):
+def make_grid(synthesizer_model_name, imf, input_dir, grid_dir):
     """Main function to convert Maraston 2013 and
     produce grids used by synthesizer
     Args:
-        model (dict):
-            dictionary containing model parameters
+        synthesizer_model_name (string):
+            name of the model to be saved.
         imf (string):
             Initial mass function, Salpeter or
             Kroupa
         input_dir (string):
             directory where the raw Maraston+13 files are read from
-        grid_dir (string):
-            directory where the grids are created.
         grid_dir (string):
             directory where the grids are created.
     Returns:
@@ -32,15 +31,11 @@ def make_grid(model, imf, input_dir, grid_dir):
     """
 
     # define output
-    out_filename = f"{grid_dir}/{sps_name}_{imf}.hdf5"
-    out_filename = f"{grid_dir}/{sps_name}_{imf}.hdf5"
+    out_filename = f"{grid_dir}/{synthesizer_model_name}.hdf5"
 
     metallicities = np.array(
         [0.001, 0.01, 0.02, 0.04]
     )  # array of available metallicities
-
-    if imf == "kroupa100":
-        metallicities = np.array([0.02])
 
     metallicity_codes = {
         0.001: "0001",
@@ -115,12 +110,7 @@ if __name__ == "__main__":
     # Define the model metadata
     sps_name = "maraston13"
     imfs = ["salpeter", "kroupa"]
-    imf_code = {"salpeter": "ss", "kroupa": "kr", "kroupa100": "100kr"}
-    model = {
-        "sps_name": sps_name,
-        "sps_version": False,
-        "alpha": False,
-    }
+    imf_code = {"salpeter": "ss", "kroupa": "kr"}
 
     input_dir = args.input_dir
     input_dir += f"/{sps_name}"
@@ -129,10 +119,20 @@ if __name__ == "__main__":
     if not os.path.exists(input_dir):
         os.mkdir(input_dir)
 
-    # run the single kroupa100 model
-    imf = "kroupa100"
-    make_grid(model, imf, input_dir, grid_dir)
-
     # then run the rest
     for imf in imfs:
-        make_grid(model, imf, input_dir, grid_dir)
+        
+        model = {
+            "sps_name": sps_name,
+            "sps_version": False,
+            "sps_variant": False,
+            "imf_type": imf,
+            "imf_masses": [0.1, 100],
+            "imf_slopes": False,
+            "alpha": False,
+            }
+        
+        synthesizer_model_name = get_model_filename(model)
+        print(synthesizer_model_name)
+                
+        make_grid(synthesizer_model_name, imf, input_dir, grid_dir)

--- a/src/synthesizer_grids/incident/sps/install_maraston13.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston13.py
@@ -6,10 +6,11 @@ import os
 
 import numpy as np
 from synthesizer.conversions import llam_to_lnu
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Angstrom, Hz, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def make_grid(synthesizer_model_name, imf, input_dir, grid_dir):
@@ -121,7 +122,6 @@ if __name__ == "__main__":
 
     # then run the rest
     for imf in imfs:
-        
         model = {
             "sps_name": sps_name,
             "sps_version": False,
@@ -130,9 +130,9 @@ if __name__ == "__main__":
             "imf_masses": [0.1, 100],
             "imf_slopes": False,
             "alpha": False,
-            }
-        
+        }
+
         synthesizer_model_name = get_model_filename(model)
         print(synthesizer_model_name)
-                
+
         make_grid(synthesizer_model_name, imf, input_dir, grid_dir)

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -7,14 +7,16 @@ import os
 
 import numpy as np
 from synthesizer.conversions import llam_to_lnu
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Angstrom, Hz, dimensionless, erg, s, yr
 from utils import get_model_filename
 
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
-def make_grid(synthesizer_model_name, rotation, model_type, imf, 
-              input_dir, grid_dir):
+
+def make_grid(
+    synthesizer_model_name, rotation, model_type, imf, input_dir, grid_dir
+):
     """Main function to convert Maraston 2024 and
     produce grids used by synthesizer
     Args:
@@ -48,7 +50,7 @@ def make_grid(synthesizer_model_name, rotation, model_type, imf,
         0.014: "+0.00",  # solar metallicity
         0.02: "+0.35",
     }
-    
+
     if model_type == "Tenc":
         model_type = "_Tenc"
 
@@ -130,17 +132,16 @@ if __name__ == "__main__":
     for imf in imfs:
         for model_type in model_types:
             for rotation in rotations:
-                
                 if imf == "kr":
                     imf_type = "kroupa"
                 if imf == "ss":
                     imf_type = "salpeter"
-                    
+
                 if model_type == "Tenc":
                     variant_name = f"Tenc_{rotation}"
                 if model_type == "":
                     variant_name = rotation
-                
+
                 model = {
                     "sps_name": sps_name,
                     "sps_version": False,
@@ -150,11 +151,15 @@ if __name__ == "__main__":
                     "imf_slopes": False,
                     "alpha": False,
                 }
-                
+
                 synthesizer_model_name = get_model_filename(model)
                 print(synthesizer_model_name)
-                    
+
                 make_grid(
-                    synthesizer_model_name, rotation, model_type, imf, 
-                    input_dir, grid_dir
+                    synthesizer_model_name,
+                    rotation,
+                    model_type,
+                    imf,
+                    input_dir,
+                    grid_dir,
                 )

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -10,14 +10,16 @@ from synthesizer.conversions import llam_to_lnu
 from synthesizer_grids.grid_io import GridFile
 from synthesizer_grids.parser import Parser
 from unyt import Angstrom, Hz, dimensionless, erg, s, yr
+from utils import get_model_filename
 
 
-def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
+def make_grid(synthesizer_model_name, rotation, model_type, imf, 
+              input_dir, grid_dir):
     """Main function to convert Maraston 2024 and
     produce grids used by synthesizer
     Args:
-        model (dict):
-            dictionary containing model parameters.
+        synthesizer_model_name (string):
+            name of the model to be saved.
         rotation (string):
             value of stellar rotation for the model,
             "0.00" for no rotation or "0.40" for rotation.
@@ -30,15 +32,10 @@ def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
             directory where the raw Maraston+24 files are read from.
         grid_dir (string):
             directory where the grids are created.
-        grid_dir (string):
-            directory where the grids are created.
     Returns:
         fname (string):
             output filename
     """
-
-    # Define output
-    out_filename = f"{grid_dir}/{sps_name}{model_type}_{imf}_{rotation}.hdf5"
 
     # Array of available metallicities
     metallicities = np.array([0.0003, 0.002, 0.006, 0.014, 0.02])
@@ -51,6 +48,9 @@ def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
         0.014: "+0.00",  # solar metallicity
         0.02: "+0.35",
     }
+    
+    if model_type == "Tenc":
+        model_type = "_Tenc"
 
     # Open first raw data file to get age
     fn = (
@@ -71,7 +71,7 @@ def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
     spec = np.zeros((len(ages), len(metallicities), len(lam)))
 
     # Create the GridFile ready to take outputs
-    out_grid = GridFile(out_filename)
+    out_grid = GridFile(f"{grid_dir}/{synthesizer_model_name}.hdf5")
 
     log_on_read = {"ages": True, "metallicities": False}
 
@@ -118,14 +118,8 @@ if __name__ == "__main__":
     # Define the model metadata
     sps_name = "maraston24"
     rotations = ["0.00", "0.40"]
-    model_types = ["", "_Tenc"]
+    model_types = ["", "Tenc"]
     imfs = ["kr", "ss"]
-    max_stellar_masses = ["", "_300"]
-    model = {
-        "sps_name": sps_name,
-        "sps_version": False,
-        "alpha": False,
-    }
 
     input_dir = f"{args.input_dir}/{sps_name}"
 
@@ -136,7 +130,31 @@ if __name__ == "__main__":
     for imf in imfs:
         for model_type in model_types:
             for rotation in rotations:
-                print(imf, model_type, rotation)
+                
+                if imf == "kr":
+                    imf_type = "kroupa"
+                if imf == "ss":
+                    imf_type = "salpeter"
+                    
+                if model_type == "Tenc":
+                    variant_name = f"Tenc_{rotation}"
+                if model_type == "":
+                    variant_name = rotation
+                
+                model = {
+                    "sps_name": sps_name,
+                    "sps_version": False,
+                    "sps_variant": variant_name,
+                    "imf_type": imf_type,
+                    "imf_masses": [0.1, 100],
+                    "imf_slopes": False,
+                    "alpha": False,
+                }
+                
+                synthesizer_model_name = get_model_filename(model)
+                print(synthesizer_model_name)
+                    
                 make_grid(
-                    model, rotation, model_type, imf, input_dir, grid_dir
+                    synthesizer_model_name, rotation, model_type, imf, 
+                    input_dir, grid_dir
                 )


### PR DESCRIPTION
Adds `get_model_filename` to the Maraston scripts which didn't have them

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the grid generation process with a simplified naming approach for output files, ensuring a consistent and more straightforward workflow.
  
- **Documentation**
  - Updated in-app explanations to reflect the new, streamlined grid creation method, including changes to parameter names and output filename construction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->