### PR TITLE
Pass model dicts, improve M24 variant naming, run ruff

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,4 +114,4 @@ python create_synthesizer_grid.py \
 
 ## Contributing
 
-Contributions welcome. Please read the contributing guidelines [here](https://github.com/flaresimulations/synthesizer/blob/main/docs/CONTRIBUTING.md).
+Contributions welcome. Please read the contributing guidelines [here](https://github.com/synthesizer-project/synthesizer/blob/main/docs/CONTRIBUTING.md).

--- a/src/synthesizer_grids/incident/sps/install_bc03-2016.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03-2016.py
@@ -21,11 +21,12 @@ import tarfile
 
 import numpy as np
 import requests
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from tqdm import tqdm
 from unyt import Hz, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def extract_and_decompress_ised_files(directory):

--- a/src/synthesizer_grids/incident/sps/install_bc03.py
+++ b/src/synthesizer_grids/incident/sps/install_bc03.py
@@ -16,11 +16,12 @@ import tarfile
 
 import numpy as np
 import requests
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from tqdm import tqdm
 from unyt import Hz, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def decompress_gz_recursively(directory):

--- a/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
@@ -22,10 +22,11 @@ import os
 import tarfile
 
 import numpy as np
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Hz, Msun, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def resolve_name(original_model_name, bin):

--- a/src/synthesizer_grids/incident/sps/install_bpass2.3.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.3.py
@@ -26,10 +26,11 @@ Example:
 """
 
 import numpy as np
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Hz, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def resolve_name(original_model_name, bin, alpha=False):

--- a/src/synthesizer_grids/incident/sps/install_fsps.py
+++ b/src/synthesizer_grids/incident/sps/install_fsps.py
@@ -11,10 +11,11 @@ Example:
 
 import fsps
 import numpy as np
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Hz, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def generate_grid(model):

--- a/src/synthesizer_grids/incident/sps/install_fsps_variable_imf.py
+++ b/src/synthesizer_grids/incident/sps/install_fsps_variable_imf.py
@@ -10,10 +10,11 @@ Example:
 
 import fsps
 import numpy as np
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Hz, angstrom, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def generate_grid(model):

--- a/src/synthesizer_grids/incident/sps/install_maraston05.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston05.py
@@ -9,10 +9,11 @@ from pathlib import Path
 import numpy as np
 import wget
 from synthesizer.conversions import flam_to_fnu
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Hz, angstrom, cm, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def download_data(input_dir, url):

--- a/src/synthesizer_grids/incident/sps/install_maraston11.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston11.py
@@ -9,10 +9,11 @@ from pathlib import Path
 import numpy as np
 import wget
 from synthesizer.conversions import llam_to_lnu
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from unyt import Angstrom, Hz, dimensionless, erg, s, yr
 from utils import get_model_filename
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def download_data(

--- a/src/synthesizer_grids/incident/sps/install_maraston13.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston13.py
@@ -33,7 +33,7 @@ def make_grid(model, imf, input_dir, grid_dir):
 
     synthesizer_model_name = get_model_filename(model)
     print(synthesizer_model_name)
-    
+
     # define output
     out_filename = f"{grid_dir}/{synthesizer_model_name}.hdf5"
 

--- a/src/synthesizer_grids/incident/sps/install_maraston13.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston13.py
@@ -13,7 +13,7 @@ from synthesizer_grids.grid_io import GridFile
 from synthesizer_grids.parser import Parser
 
 
-def make_grid(synthesizer_model_name, imf, input_dir, grid_dir):
+def make_grid(model, imf, input_dir, grid_dir):
     """Main function to convert Maraston 2013 and
     produce grids used by synthesizer
     Args:
@@ -31,6 +31,9 @@ def make_grid(synthesizer_model_name, imf, input_dir, grid_dir):
             output filename
     """
 
+    synthesizer_model_name = get_model_filename(model)
+    print(synthesizer_model_name)
+    
     # define output
     out_filename = f"{grid_dir}/{synthesizer_model_name}.hdf5"
 
@@ -132,7 +135,4 @@ if __name__ == "__main__":
             "alpha": False,
         }
 
-        synthesizer_model_name = get_model_filename(model)
-        print(synthesizer_model_name)
-
-        make_grid(synthesizer_model_name, imf, input_dir, grid_dir)
+        make_grid(model, imf, input_dir, grid_dir)

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -15,13 +15,13 @@ from synthesizer_grids.parser import Parser
 
 
 def make_grid(
-    synthesizer_model_name, rotation, model_type, imf, input_dir, grid_dir
+    model, rotation, model_type, imf, input_dir, grid_dir
 ):
     """Main function to convert Maraston 2024 and
     produce grids used by synthesizer
     Args:
-        synthesizer_model_name (string):
-            name of the model to be saved.
+        model (dict):
+            dictionary containing model parameters.
         rotation (string):
             value of stellar rotation for the model,
             "0.00" for no rotation or "0.40" for rotation.
@@ -38,6 +38,9 @@ def make_grid(
         fname (string):
             output filename
     """
+    
+    synthesizer_model_name = get_model_filename(model)
+    print(synthesizer_model_name)
 
     # Array of available metallicities
     metallicities = np.array([0.0003, 0.002, 0.006, 0.014, 0.02])
@@ -152,11 +155,8 @@ if __name__ == "__main__":
                     "alpha": False,
                 }
 
-                synthesizer_model_name = get_model_filename(model)
-                print(synthesizer_model_name)
-
                 make_grid(
-                    synthesizer_model_name,
+                    model,
                     rotation,
                     model_type,
                     imf,

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -14,9 +14,7 @@ from synthesizer_grids.grid_io import GridFile
 from synthesizer_grids.parser import Parser
 
 
-def make_grid(
-    model, rotation, model_type, imf, input_dir, grid_dir
-):
+def make_grid(model, rotation, model_type, imf, input_dir, grid_dir):
     """Main function to convert Maraston 2024 and
     produce grids used by synthesizer
     Args:
@@ -38,7 +36,7 @@ def make_grid(
         fname (string):
             output filename
     """
-    
+
     synthesizer_model_name = get_model_filename(model)
     print(synthesizer_model_name)
 
@@ -125,7 +123,7 @@ if __name__ == "__main__":
     # Define the model metadata
     sps_name = "maraston24"
     rotations = ["00", "40"]
-    
+
     model_types = ["Te", "Tenc"]
     imfs = ["kr", "ss"]
 
@@ -142,7 +140,7 @@ if __name__ == "__main__":
                     imf_type = "kroupa"
                 if imf == "ss":
                     imf_type = "salpeter"
-                    
+
                 variant_name = f"{model_type}{rotation}"
 
                 model = {

--- a/src/synthesizer_grids/incident/sps/install_maraston24.py
+++ b/src/synthesizer_grids/incident/sps/install_maraston24.py
@@ -56,10 +56,12 @@ def make_grid(
 
     if model_type == "Tenc":
         model_type = "_Tenc"
+    if model_type == "Te":
+        model_type = ""
 
     # Open first raw data file to get age
     fn = (
-        f"{input_dir}/sed_ssp_M24_vini{rotation}{model_type}_{imf}"
+        f"{input_dir}/sed_ssp_M24_vini0.{rotation}{model_type}_{imf}"
         f"{metallicity_code[metallicities[0]]}"
     )
 
@@ -84,7 +86,7 @@ def make_grid(
     for imetal, metallicity in enumerate(metallicities):
         for ia, age_Gyr in enumerate(ages_Gyr):
             fn = (
-                f"{input_dir}/sed_ssp_M24_vini{rotation}{model_type}_{imf}"
+                f"{input_dir}/sed_ssp_M24_vini0.{rotation}{model_type}_{imf}"
                 f"{metallicity_code[metallicity]}"
             )
             ages_, _, lam_, llam_ = np.loadtxt(fn).T
@@ -122,8 +124,9 @@ if __name__ == "__main__":
 
     # Define the model metadata
     sps_name = "maraston24"
-    rotations = ["0.00", "0.40"]
-    model_types = ["", "Tenc"]
+    rotations = ["00", "40"]
+    
+    model_types = ["Te", "Tenc"]
     imfs = ["kr", "ss"]
 
     input_dir = f"{args.input_dir}/{sps_name}"
@@ -139,11 +142,8 @@ if __name__ == "__main__":
                     imf_type = "kroupa"
                 if imf == "ss":
                     imf_type = "salpeter"
-
-                if model_type == "Tenc":
-                    variant_name = f"Tenc_{rotation}"
-                if model_type == "":
-                    variant_name = rotation
+                    
+                variant_name = f"{model_type}{rotation}"
 
                 model = {
                     "sps_name": sps_name,

--- a/src/synthesizer_grids/incident/sps/install_yggdrasil.py
+++ b/src/synthesizer_grids/incident/sps/install_yggdrasil.py
@@ -31,10 +31,11 @@ import re
 import numpy as np
 import requests
 from spectres import spectres
-from synthesizer_grids.grid_io import GridFile
-from synthesizer_grids.parser import Parser
 from tqdm import tqdm
 from unyt import Hz, angstrom, c, dimensionless, erg, s, yr
+
+from synthesizer_grids.grid_io import GridFile
+from synthesizer_grids.parser import Parser
 
 
 def download_data(input_dir, ver, fcov):


### PR DESCRIPTION
Things that I have done here:
- Made sure the model dictionary was correctly passed to the Grid object when creating the M13 and M24 grids
- Improve the naming of the M24 variants, now e.g. maraston24-Tenc00_kroupa-0.1,100 
- Fixed broken link to the contributing guidelines in the README
- Ran ruff over incident grid files

## Issue Type
- Bug
- Document
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the contributing guidelines URL to point to the correct repository.

- **Chores**
  - Restored essential dependencies across multiple grid processing scripts to ensure reliable file handling and command-line parsing.

- **Refactor**
  - Streamlined parameter naming and handling within grid generation routines for improved consistency and clarity across the workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->