### PR TITLE
Always create grid, even if a mode has failed

### DIFF
--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -1000,6 +1000,8 @@ if __name__ == "__main__":
         lam = None
         spectra = None
 
+    print(spectra)
+
     # Now add lines
     add_lines(
         new_grid,

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -500,7 +500,7 @@ def add_spectra(
     spectra["normalisation"] = np.ones(new_shape)
 
     # Array for recording cloudy failures
-    spectra["failures"] = np.zeros((*new_shape, nlam))
+    failures = np.zeros((*new_shape, nlam))
 
     for incident_index, incident_index_tuple in enumerate(incident_index_list):
         for photoionisation_index, photoionisation_index_tuple in enumerate(
@@ -528,7 +528,7 @@ def add_spectra(
                     spectra[spec_name][indices] = np.zeros(nlam)
 
                 # Record failures in array
-                spectra["failures"][indices] = 1
+                failures[indices] = 1
 
             else:
                 # Read the continuum file containing the spectra
@@ -577,6 +577,13 @@ def add_spectra(
     )
 
     # Need to write the dataset containing the failures
+    new_grid.write_dataset(
+        "failures",
+        failures * dimensionless,
+        "array of model failures",
+        False,
+        verbose=False,
+    )
 
     return lam, spectra
 
@@ -653,9 +660,6 @@ def add_lines(
 
     # We always save luminosity...
     lines["luminosity"] = np.empty((*new_shape, nlines))
-
-    # And whether a model failed or not
-    # lines["failures"] = np.zeros((*new_shape, nlines)) * dimensionless
 
     # ... but only save continuum values if spectra are provided.
     if calculate_continuum:

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -655,7 +655,7 @@ def add_lines(
     lines["luminosity"] = np.empty((*new_shape, nlines))
 
     # And whether a model failed or not
-    lines["failures"] = np.zeros((*new_shape, nlines))
+    # lines["failures"] = np.zeros((*new_shape, nlines)) * dimensionless
 
     # ... but only save continuum values if spectra are provided.
     if calculate_continuum:
@@ -717,7 +717,7 @@ def add_lines(
                         lines[continuum_quantity][indices] = np.zeros(nlines)
 
                 # Record failures in array
-                lines["failures"][indices] = 1
+                # lines["failures"][indices] = 1
 
             else:
                 # Read line quantities

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -500,7 +500,7 @@ def add_spectra(
     spectra["normalisation"] = np.ones(new_shape)
 
     # Array for recording cloudy failures
-    failures = np.zeros((*new_shape, nlam))
+    failures = np.zeros(*new_shape)
 
     for incident_index, incident_index_tuple in enumerate(incident_index_list):
         for photoionisation_index, photoionisation_index_tuple in enumerate(
@@ -689,6 +689,9 @@ def add_lines(
         for continuum_quantity in continuum_quantities:
             lines[continuum_quantity] = np.empty((*new_shape, nlines))
 
+    # Array for recording cloudy failures
+    failures = np.zeros(*new_shape)
+
     # Loop over incident models and photoionisation models
     for incident_index, incident_index_tuple in enumerate(incident_index_list):
         for photoionisation_index, photoionisation_index_tuple in enumerate(
@@ -721,7 +724,7 @@ def add_lines(
                         lines[continuum_quantity][indices] = np.zeros(nlines)
 
                 # Record failures in array
-                # lines["failures"][indices] = 1
+                failures[indices] = 1
 
             else:
                 # Read line quantities
@@ -779,6 +782,16 @@ def add_lines(
     # Write the lines out
     new_grid.write_lines(
         lines,
+    )
+
+    # Need to write the dataset containing the failures
+    # This is repeated if spectra were made.
+    new_grid.write_dataset(
+        "failures",
+        failures * dimensionless,
+        "array of model failures",
+        False,
+        verbose=False,
     )
 
 

--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -655,7 +655,7 @@ def add_lines(
     lines["luminosity"] = np.empty((*new_shape, nlines))
 
     # And whether a model failed or not
-    lines["failures"] = np.empty((*new_shape, nlines))
+    lines["failures"] = np.zeros((*new_shape, nlines))
 
     # ... but only save continuum values if spectra are provided.
     if calculate_continuum:
@@ -999,8 +999,6 @@ if __name__ == "__main__":
     else:
         lam = None
         spectra = None
-
-    print(spectra)
 
     # Now add lines
     add_lines(


### PR DESCRIPTION
If very large complex photoionisation grids some models perennially fail. To address this, this PR changes the synthesizer grid creation pipeline to still create the grid. This allows us to 1) better diagnose the source of faults and 2) potentially still use the grid. 

For context, in one of the AGN grid runs about 0.1% of grid points have failed. 

The code still produces copious of warning of failures but still attempts to create a grid.


## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Models that fail during processing are now explicitly flagged, with failure information saved in the output datasets.
  - Grids are created even if some models fail, with failed models represented by zeroed data.

- **Improvements**
  - Failure detection is now more consistent and robust, centralizing logic for determining failed models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->