### PR TITLE
Fix bug in install_qsosed and install_relqso

### DIFF
--- a/src/synthesizer_grids/incident/blackholes/install_qsosed.py
+++ b/src/synthesizer_grids/incident/blackholes/install_qsosed.py
@@ -25,7 +25,7 @@ sys.path.append("RELAGN/src/python_version")
 
 if __name__ == "__main__":
     # Import relagn module
-    from relagn import relagn  # noqa: E402
+    from relagn import relagn, relqso  # noqa: E402
 
     """
     Create incident AGN spectra assuming the QSOSED model.
@@ -130,7 +130,7 @@ if __name__ == "__main__":
         ):
             if isotropic:
                 # spin is assumed to be zero here
-                dagn = relagn(
+                dagn = relqso(
                     a=0.0,
                     cos_inc=cosine_inclination,
                     log_mdot=np.log10(accretion_rate_eddington_),
@@ -147,7 +147,7 @@ if __name__ == "__main__":
                     axes_values["cosine_inclinations"]
                 ):
                     # spin is assumed to be zero here
-                    dagn = relagn(
+                    dagn = relqso(
                         a=0.0,
                         cos_inc=cosine_inclination_,
                         log_mdot=np.log10(accretion_rate_eddington_),

--- a/src/synthesizer_grids/incident/blackholes/install_relqso.py
+++ b/src/synthesizer_grids/incident/blackholes/install_relqso.py
@@ -16,15 +16,16 @@ import sys
 
 import numpy as np
 import yaml
+from unyt import Angstrom, Hz, Msun, dimensionless, erg, s
+
 from synthesizer_grids.grid_io import GridFile
 from synthesizer_grids.parser import Parser
-from unyt import Angstrom, Hz, Msun, dimensionless, erg, s
 
 sys.path.append("RELAGN/src/python_version")
 
 if __name__ == "__main__":
     # Import relagn module
-    from relagn import relagn  # noqa: E402
+    from relagn import relagn, relqso  # noqa: E402
 
     """
     Create incident AGN spectra assuming the RELQSO model.
@@ -134,7 +135,7 @@ if __name__ == "__main__":
         ):
             for i3, spin_ in enumerate(axes_values["spins"]):
                 if isotropic:
-                    dagn = relagn(
+                    dagn = relqso(
                         a=spin_,
                         cos_inc=cosine_inclination,
                         log_mdot=np.log10(accretion_rate_eddington_),
@@ -152,7 +153,7 @@ if __name__ == "__main__":
                     for i4, cosine_inclination_ in enumerate(
                         axes_values["cosine_inclinations"]
                     ):
-                        dagn = relagn(
+                        dagn = relqso(
                             a=spin_,
                             cos_inc=cosine_inclination_,
                             log_mdot=np.log10(accretion_rate_eddington_),


### PR DESCRIPTION
A rather embarrassing bug. For `install_qsosed` and `install_relqso` we should have been using the class `relqso` from `relagn`. Fixed now, mostly affects x-ray predictions. 


## Issue Type
- [x] Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the spectral synthesis process to use a different AGN model for incident spectrum generation in both isotropic and non-isotropic scenarios. There are no changes to the user-facing interface or outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->