### PR TITLE
Single line regex fix to Yggdrasil grid generation.

### DIFF
--- a/src/synthesizer_grids/incident/sps/install_yggdrasil.py
+++ b/src/synthesizer_grids/incident/sps/install_yggdrasil.py
@@ -130,7 +130,7 @@ def convertPOPIII(fileloc):
     """
     data = open(fileloc, "r")
     tmp = data.readlines()
-    mass = float(re.findall(r"\d+\.\d+(?:[eE][+-]?\d+)?", tmp[0])[0])     
+    mass = float(re.findall(r"\d+\.\d+(?:[eE][+-]?\d+)?", tmp[0])[0])
     begin = 9
     end = begin + lam_num[0]
     for ii in range(len(ageBins)):

--- a/src/synthesizer_grids/incident/sps/install_yggdrasil.py
+++ b/src/synthesizer_grids/incident/sps/install_yggdrasil.py
@@ -130,7 +130,7 @@ def convertPOPIII(fileloc):
     """
     data = open(fileloc, "r")
     tmp = data.readlines()
-    mass = float(re.findall(r"\d+\.\d+", tmp[0])[0])
+    mass = float(re.findall(r"\d+\.\d+(?:[eE][+-]?\d+)?", tmp[0])[0])     
     begin = 9
     end = begin + lam_num[0]
     for ii in range(len(ageBins)):


### PR DESCRIPTION
There was an issue with gas masses with scientific notation (e.g. 1e6 Msun) being read in as 1 Msun, resulting in incorrect normalizations for spectra with covering factors >0 for the Yggdrasil grids. This PR fixes the regex to read in both scientific and standard notation masses correctly. 

## Issue Type
- Bug




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of mass values to correctly handle numbers in scientific notation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->