### PR TITLE
Add incident continuum calculation

### DIFF
--- a/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
+++ b/src/synthesizer_grids/cloudy/create_synthesizer_grid.py
@@ -665,11 +665,15 @@ def add_lines(
     if calculate_continuum:
         continuum_quantities = [
             "transmitted",
+            "incident",
             "nebular_continuum",
             "total_continuum",
         ]
 
         spectra_ = {}
+
+        # Calculate incideted_contiuum
+        spectra_["incident"] = spectra["incident"]
 
         # Calculate transmitted_contiuum
         spectra_["transmitted"] = spectra["transmitted"]


### PR DESCRIPTION
Now calculates the incident continuum emission at each line, similar to transmitted. This enables harmonisation with a wider selection of synthesizer emission models.

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for calculating and saving the "incident" continuum quantity when spectra are provided.

- **Bug Fixes**
  - Ensured the "incident" continuum is available for continuum luminosity calculations at line wavelengths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->