### PR TITLE
Unit fix for remnant and stellar fraction for BPASS v2.2.1 grids

### DIFF
--- a/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
+++ b/src/synthesizer_grids/incident/sps/install_bpass2.2.1.py
@@ -195,13 +195,13 @@ def make_grid(original_model_name, bin, input_dir, grid_dir):
     # Write datasets specific to BPASS
     out_grid.write_dataset(
         "star_fraction",
-        stellar_fraction * Msun,
+        stellar_fraction * dimensionless,
         "Two-dimensional remaining stellar fraction grid, [age, Z]",
         log_on_read=False,
     )
     out_grid.write_dataset(
         "remnant_fraction",
-        remnant_fraction * Msun,
+        remnant_fraction * dimensionless,
         "Two-dimensional remaining remnant fraction grid, [age, Z]",
         log_on_read=False,
     )


### PR DESCRIPTION
The BPASS 2.2.1 script has a utlity for saving the stellar_fraction and remnant fraction to the grid. These are loaded as fractions of the total formed mass (0 < f <=1 ), but were being given the unit Msun on writing (which often seems to be annoyingly arbitrarily converted to kg by unyt), resulting in fractions of ~10^30. This PR simply switches them to the appropriate 'dimensionless'. 

## Issue Type
- Enhancement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected units for BPASS grid outputs: star_fraction and remnant_fraction are now reported as unitless fractions instead of mass-scaled values, ensuring accurate interpretation and consistency in analyses.
  - No changes to public interfaces or controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->