### PR TITLE
Add surviving fraction calculation to fsps grid generation scripts

### DIFF
--- a/src/synthesizer_grids/incident/sps/install_fsps.py
+++ b/src/synthesizer_grids/incident/sps/install_fsps.py
@@ -77,13 +77,16 @@ def generate_grid(model):
     nmetal = len(metallicities)
 
     spec = np.zeros((na, nmetal, len(lam)))
+    stellar_fraction = np.zeros((na, nmetal))
 
     for imetal in range(nmetal):
         spec_ = sp.get_spectrum(zmet=imetal + 1)[1]  # 2D array Lsol / AA
+        _mfrac = sp.stellar_mass / sp.formed_mass
         for ia in range(na):
             lnu = spec_[ia]  # Lsol / Hz
             lnu *= 3.826e33  # erg s^-1 Hz^-1 Msol^-1
             spec[ia, imetal] = lnu
+            stellar_fraction[ia, imetal] = _mfrac[ia]
 
     # Create the GridFile ready to take outputs
     out_grid = GridFile(out_filename)
@@ -107,6 +110,14 @@ def generate_grid(model):
         alt_axes=("log10ages", "metallicities"),
         log_on_read=log_on_read,
         weight="initial_masses",
+    )
+
+    # Write datasets specific to fsps
+    out_grid.write_dataset(
+        "star_fraction",
+        stellar_fraction * dimensionless,
+        "Two-dimensional remaining stellar fraction grid, [age, Z]",
+        log_on_read=False,
     )
 
     # Include the specific ionising photon luminosity

--- a/src/synthesizer_grids/incident/sps/install_fsps_variable_imf.py
+++ b/src/synthesizer_grids/incident/sps/install_fsps_variable_imf.py
@@ -55,6 +55,7 @@ def generate_grid(model):
 
     # Define the output array
     spec = np.zeros((na, nmetal, len(high_mass_slopes), len(lam)))
+    stellar_fraction = np.zeros((na, nmetal, len(high_mass_slopes)))
 
     for high_mass_slope_index, high_mass_slope in enumerate(high_mass_slopes):
         print(high_mass_slope)
@@ -78,7 +79,7 @@ def generate_grid(model):
         # Loop over metallicity
         for metallicity_index in range(nmetal):
             spec_ = sp.get_spectrum(zmet=metallicity_index + 1)[1]
-
+            _mfrac = sp.stellar_mass / sp.formed_mass
             # Loop over age
             for age_index in range(na):
                 # Extract spectra in Lsol / Hz
@@ -89,6 +90,9 @@ def generate_grid(model):
 
                 # Assign to array
                 spec[age_index, metallicity_index, high_mass_slope_index] = lnu
+                stellar_fraction[
+                    age_index, metallicity_index, high_mass_slope_index
+                ] = _mfrac[age_index]
 
     # Create the GridFile ready to take outputs
     out_grid = GridFile(out_filename)
@@ -117,6 +121,14 @@ def generate_grid(model):
             "high_mass_slope": "high mass (>0.5 Msun) slope of the IMF"
         },
         log_on_read=log_on_read,
+    )
+
+    # Write datasets specific to fsps
+    out_grid.write_dataset(
+        "star_fraction",
+        stellar_fraction * dimensionless,
+        "Three-dimensional remaining stellar fraction grid, [age, Z, high_mass_slope]",
+        log_on_read=False,
     )
 
     # Include the specific ionising photon luminosity


### PR DESCRIPTION
Similar to the BPASS v2.2.1 grid generation script, this PR adds surviving fraction calculation to the fsps grid generation scripts.

fsps.StellarPopulation returns all information needed for this already, this just assigns it to a new array and saves it to the HDF5 file. Note that for the variable high-mass slope script, this results in a three-dimensional stellar fraction to account for the variation in high-mass slope. We may need a method on Grid to collapse the dimensionality of the stellar fraction array for these higher-dimensional grids. 

R.e. the other models - 
 - BPASS 2.3 - stellar_fraction doesn't appear to be publicly available for BPASS v2.3.
 - BC03/BC03 2016 - This information is available, but will need another custom loader to parse the *.4color files, which aren't currently used.
 - Maraston - not sure, the link I found to download the raw data didn't work.
 - Yggdrasil - Available for some, but not the Pop III models (according to the FAQ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - FSPS-generated grids now include a remaining stellar mass fraction dataset alongside spectra.
  - For fixed IMF: provided as a 2D grid over age and metallicity.
  - For variable IMF: provided as a 3D grid over age, metallicity, and high-mass slope.
  - Exported with dimensionless scaling; existing outputs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->